### PR TITLE
Misleading range of input for reducePayneHanek() in FastMath.java of util package

### DIFF
--- a/src/main/java/org/apache/commons/math4/util/FastMath.java
+++ b/src/main/java/org/apache/commons/math4/util/FastMath.java
@@ -2091,7 +2091,7 @@ public class FastMath {
     }
 
     /** Reduce the input argument using the Payne and Hanek method.
-     *  This is good for all inputs 0.0 < x < inf
+     *  This is good for inputs 0.5 < x < inf
      *  Output is remainder after dividing by PI/2
      *  The result array should contain 3 numbers.
      *  result[0] is the integer portion, so mod 4 this gives the quadrant.


### PR DESCRIPTION
The documentation says: `This is good for all inputs 0.0 < x < inf`

However, if we look at the implementation, the variable `idx` will be evaluated to a negative value for the range `0.0 <= x < 0.5.`, which will throw `ArrayIndexOutOfBoundsException`.

Hence, the range should be `0.5 <= x < inf.`

For example:
If x = 0.4,
idx = -1